### PR TITLE
Hot Fix: fixed duplicate sending of news

### DIFF
--- a/helpers/guild-helper.js
+++ b/helpers/guild-helper.js
@@ -2,8 +2,8 @@ module.exports = {
     _ListOfGuilds: [],
     _ListOfDefaultChannels: [],
     initialize(bot) {
-        bot.guilds.map(guild => {
-            this.addGuild(guild)
+        bot.guilds.array().forEach(guild => {
+            this.addGuild(guild);
             this.addNotifyChannel(guild.channels.filter(channel => channel.type === 'text').first());
         });
     },
@@ -11,8 +11,13 @@ module.exports = {
         this._ListOfDefaultChannels.push(channel);
     },
     addGuild(guild) {
-        this._ListOfGuilds.push(guild);
-        this.addNotifyChannel(guild.channels.filter(channel => channel.type === 'text').first());
+        const channel = guild.channels.filter(channel => channel.type === 'text').first();
+        if (!this._ListOfGuilds.includes(guild)) {
+            this._ListOfGuilds.push(guild);
+            if (this._ListOfDefaultChannels.includes(channel)) {
+                this.addNotifyChannel(channel);
+            }
+        }
     },
     getNotifyChannels() {
         return this._ListOfDefaultChannels;
@@ -20,11 +25,11 @@ module.exports = {
     getGuildList() {
         return this._ListOfGuilds;
     },
-    removeGuild(guild){
+    removeGuild(guild) {
         this._ListOfGuilds.splice(this._ListOfGuilds.indexOf(guild), 1);
         this.removeNotifyChannel(guild.id);
     },
-    removeNotifyChannel(id){
+    removeNotifyChannel(id) {
         this._ListOfDefaultChannels.splice(this._ListOfDefaultChannels.indexOf(this._ListOfDefaultChannels.filter(x => x.guild.id === id)), 1);
     }
 }


### PR DESCRIPTION
There was an issue where the array of channels to send messages to was being populated twice with duplicate IDs